### PR TITLE
handle tkinter exception to support non-display environment

### DIFF
--- a/make_timeline.py
+++ b/make_timeline.py
@@ -422,6 +422,8 @@ if __name__ == '__main__':
     if not os.path.isfile(filename):
         print('file %s not found' % filename)
         sys.exit(-1)
+    if os.environ.get('DISPLAY','') == '':
+        os.environ['DISPLAY'] = ':0'
     timeline = Timeline(filename)
     timeline.build()
     print(timeline.to_string().encode('utf-8'))

--- a/make_timeline.py
+++ b/make_timeline.py
@@ -9,7 +9,7 @@ import json
 import os.path
 import sys
 
-if sys.version_info[0]==3:
+if sys.version_info[0] == 3:
     # for Python3
     import tkinter as Tkinter
     import tkinter.font as tkFont

--- a/make_timeline.py
+++ b/make_timeline.py
@@ -9,18 +9,15 @@ import json
 import os.path
 import sys
 
-try:
-    # for Python2
-    import Tkinter
-except ImportError:
+if sys.version_info[0]==3:
     # for Python3
     import tkinter as Tkinter
-
-try:
-    import tkFont
-except ImportError:
     import tkinter.font as tkFont
-
+    from tkinter import _tkinter
+else:
+    # for Python2
+    import Tkinter
+    import tkFont
 
 class Colors:
 
@@ -106,7 +103,12 @@ class Timeline:
         self.ticks = {}
 
         # initialize Tk so that font metrics will work
-        self.tk_root = Tkinter.Tk()
+        self.use_tkinter = True
+        try:
+            self.tk_root = Tkinter.Tk()
+        except _tkinter.TclError:
+            print('_tkinter.TclError is raised')
+            self.use_tkinter = False
         self.fonts = {}
 
         # leveler for ticks
@@ -397,6 +399,9 @@ class Timeline:
         return get_level.min_y
 
     def get_text_metrics(self, family, size, text):
+        if not self.use_tkinter:
+            # NOTE: change it not to use hard-coded value
+            return (len(text)*10, 10)
         font = None
         key = (family, size)
         if key in self.fonts:
@@ -407,7 +412,6 @@ class Timeline:
         assert font is not None
         (w, h) = (font.measure(text), font.metrics('linespace'))
         return (w, h)
-
 
 def usage():
     print('Usage: ./make_timeline.py in.json > out.svg')
@@ -422,8 +426,6 @@ if __name__ == '__main__':
     if not os.path.isfile(filename):
         print('file %s not found' % filename)
         sys.exit(-1)
-    if os.environ.get('DISPLAY','') == '':
-        os.environ['DISPLAY'] = ':0'
     timeline = Timeline(filename)
     timeline.build()
     print(timeline.to_string().encode('utf-8'))


### PR DESCRIPTION
If DISPLAY is unset, an exception occurs like below.

Traceback (most recent call last):
  File "./make_timeline.py", line 425, in <module>
timeline = Timeline(filename)
  File "./make_timeline.py", line 109, in __init__
    self.tk_root = Tkinter.Tk()
  File "/usr/lib/python3.4/tkinter/__init__.py", line 1854, in __init__
    self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
_tkinter.TclError: no display name and no $DISPLAY environment variable

So I made this commit, and I think it is a possible fix for this issue.
